### PR TITLE
Upgrade base image to PHP 7.4 (Debian bullseye) + add CD workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,64 @@
+name: CD Build
+
+on:
+  push:
+    tags:
+      - '**'
+
+env:
+  AWS_REGION: eu-west-3
+  ECR_REPOSITORY: php-7-fpm-supervisor
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    if: github.repository_owner == 'Guidap'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set release version
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.GUIDAP_LEGACY_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.GUIDAP_LEGACY_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+        with:
+          mask-password: 'false'
+
+      - name: Build, tag and push image to Amazon ECR
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        run: |
+          docker build --no-cache -t $ECR_REGISTRY/$ECR_REPOSITORY:$RELEASE_VERSION .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$RELEASE_VERSION
+          echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$RELEASE_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Notify job status
+        if: always()
+        uses: fjogeleit/http-request-action@v1
+        with:
+          url: ${{ secrets.CI_NOTIFICATION_ENDPOINT }}
+          method: 'POST'
+          username: ${{ secrets.CI_NOTIFICATION_USER }}
+          password: ${{ secrets.CI_NOTIFICATION_PASSWORD }}
+          data: |-
+            {
+              "status": "${{ job.status }}",
+              "ref": "${{ github.ref }}",
+              "repository": "${{ github.repository }}",
+              "initiator": "${{ github.actor }}",
+              "workflow": "${{ github.workflow }}",
+              "run_url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,7 +3,7 @@ name: CD Build
 on:
   push:
     tags:
-      - '*.*'
+      - '**'
 
 env:
   AWS_REGION: eu-west-3

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -18,13 +18,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v6.0.2
 
       - name: Set release version
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
         with:
           aws-access-key-id: ${{ secrets.GUIDAP_LEGACY_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.GUIDAP_LEGACY_AWS_SECRET_ACCESS_KEY }}
@@ -32,7 +32,7 @@ jobs:
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419 # v2.1.5
 
       - name: Build, tag and push image to Amazon ECR
         env:
@@ -44,7 +44,7 @@ jobs:
 
       - name: Notify job status
         if: always()
-        uses: fjogeleit/http-request-action@v1
+        uses: fjogeleit/http-request-action@551353b829c3646756b2ec2b3694f819d7957495 # v2.0.0
         with:
           url: ${{ secrets.CI_NOTIFICATION_ENDPOINT }}
           method: 'POST'

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,7 +3,7 @@ name: CD Build
 on:
   push:
     tags:
-      - '**'
+      - 'v*.*.*'
 
 env:
   AWS_REGION: eu-west-3
@@ -13,18 +13,22 @@ defaults:
   run:
     shell: bash
 
+permissions: {}
+
 jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v6.0.2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set release version
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           aws-access-key-id: ${{ secrets.GUIDAP_LEGACY_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.GUIDAP_LEGACY_AWS_SECRET_ACCESS_KEY }}
@@ -32,7 +36,7 @@ jobs:
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419 # v2.1.5
+        uses: aws-actions/amazon-ecr-login@376925c9d111252e87ae59691e5a442dd100ef6a # v2.1.3
 
       - name: Build, tag and push image to Amazon ECR
         env:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,7 +3,7 @@ name: CD Build
 on:
   push:
     tags:
-      - 'v*.*.*'
+      - '*.*'
 
 env:
   AWS_REGION: eu-west-3
@@ -30,8 +30,8 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
-          aws-access-key-id: ${{ secrets.GUIDAP_LEGACY_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.GUIDAP_LEGACY_AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.GUIDAP_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.GUIDAP_AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Login to Amazon ECR

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -15,7 +15,6 @@ defaults:
 
 jobs:
   build:
-    if: github.repository_owner == 'Guidap'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -34,8 +33,6 @@ jobs:
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
-        with:
-          mask-password: 'false'
 
       - name: Build, tag and push image to Amazon ECR
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4-fpm
+FROM php:7.4-fpm-bullseye
 LABEL authors="Sylvain Marty <sylvain@guidap.co>"
 
 ARG TIMEZONE=Europe/Paris

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,33 @@
-FROM php:7.2-fpm-alpine
+FROM php:7.4-fpm
 LABEL authors="Sylvain Marty <sylvain@guidap.co>"
 
 ARG TIMEZONE=Europe/Paris
 
-
-RUN apk add --no-cache \
-        $PHPIZE_DEPS \
-        tzdata \
-        imagemagick-dev \
-        libcurl \
-        zlib-dev \
-        icu-dev \
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        libmagickwand-dev \
+        libmagickcore-dev \
+        libcurl4-gnutls-dev \
+        zlib1g-dev \
+        libicu-dev \
+        libzip-dev \
+        libonig-dev \
+        libpng-dev \
         supervisor \
         curl \
         make \
-        libzip \
-        libpng-dev \
         pngquant \
         jpegoptim \
         wkhtmltopdf \
-        && cp /usr/share/zoneinfo/$TIMEZONE /etc/localtime \
-        && echo "$TIMEZONE" > /etc/timezone \
-        && apk del tzdata
+        tzdata \
+    && cp /usr/share/zoneinfo/$TIMEZONE /etc/localtime \
+    && echo "$TIMEZONE" > /etc/timezone \
+    && pecl install imagick \
+    && docker-php-ext-enable imagick \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN pecl install \
-        imagick \
-        xdebug \
-        unzip \
+        xdebug-3.1.5 \
     && docker-php-ext-install \
         pdo_mysql \
         intl \
@@ -46,12 +47,6 @@ COPY 00-supervisor.conf /etc/supervisor/conf.d/
 # Composer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
     && rm -rf /tmp/* /var/tmp/*
-
-# Installing wkhtmltopdf
-# RUN apk add --no-cache libfontenc1 libxfont1 xfonts-75dpi xfonts-base xfonts-encodings xfonts-utils \
-#     && curl -sL https://downloads.wkhtmltopdf.org/0.12/0.12.5/wkhtmltox_0.12.5-1.stretch_amd64.deb --output /tmp/wkhtmltox.deb --silent \
-#     && dpkg -i /tmp/wkhtmltox.deb \
-#     && rm /tmp/wkhtmltox.deb
 
 # Fixes permissions
 RUN chmod -R g+rwx /var/www/html \


### PR DESCRIPTION
## Summary
- Bump base from \`php:7.2-fpm\` (Debian buster, EOL) to \`php:7.4-fpm\` (Debian bullseye)
- Stay on Debian (not alpine): the previously published image \`guidap/php-7-fpm-supervisor:v2.1.0\` is in fact Debian buster — downstream consumers (\`guidap-worker\`, \`guidap-cron\`, \`guidap-client\`) all assume \`apt-get\` and Debian .deb installs (datadog tracer)
- apt: add \`libonig-dev\` + \`libzip-dev\` (PHP 7.4 mbstring/zip requirements), keep \`wkhtmltopdf\` from apt
- xdebug pinned to \`3.1.5\` (PHP 7.4-compatible)
- Add CD workflow (\`.github/workflows/cd.yml\`) triggered on git tag push, pushes to ECR (\`php-7-fpm-supervisor\` repo). Same secret pattern as the legacy app CD.

## Why
Companion of \`Guidap/php-7-fpm-nginx#3\`. The legacy app moves to PHP 7.4 and needs both base images bumped in sync.

## Test plan
- [ ] \`docker build .\` succeeds on linux/amd64
- [ ] \`guidap-worker\`/\`guidap-cron\`/\`guidap-client\` Dockerfiles in \`Guidap/guidap\` (PR #4351) build successfully using this image as base
- [ ] After merge, push a versioned tag (e.g. \`v2.3.0\`) and verify the CD workflow pushes to ECR

Generated with [Claude Code](https://claude.com/claude-code)
